### PR TITLE
Fix mono font referenced by Text Viewer dialog

### DIFF
--- a/xml/Font.xml
+++ b/xml/Font.xml
@@ -149,6 +149,11 @@
 			<size>120</size>
 		</font>
 		<font>
+			<name>Mono26</name>
+			<filename>NotoMono-Regular.ttf</filename>
+			<size>26</size>
+		</font>
+		<font>
 			<name>Mono30</name>
 			<filename>NotoMono-Regular.ttf</filename>
 			<size>30</size>
@@ -701,6 +706,11 @@
 			<filename>arial.ttf</filename>
 			<size>100</size>
 			<style>bold</style>
+		</font>
+		<font>
+			<name>Mono26</name>
+			<filename>arial.ttf</filename>
+			<size>26</size>
 		</font>
 		<font>
 			<name>Mono30</name>


### PR DESCRIPTION
Mono26 is [used by DialogTextViewer.xml][1], but it was missing from the
Font.xml and so Kodi was falling back to the default sans-serif font.

This PR restores Mono26 to the fonts definition as it is in the
standard Estuary skin, so now when a DialogTextViewer is shown with
`usemono=True`, it will properly display with a monospace font.

[1]: https://github.com/b-jesch/skin.estuary.modv2/blob/master/xml/DialogTextViewer.xml#L16-L25