### PR TITLE
fix unmatched parentheses

### DIFF
--- a/xml/Includes_MediaMenu.xml
+++ b/xml/Includes_MediaMenu.xml
@@ -167,7 +167,7 @@
 				<control type="radiobutton" id="6058">
 					<include>MediaMenuItemsCommonRadio</include>
 					<label>$LOCALIZE[40409]</label>
-					<selected>!Skin.HasSetting(ShowPVRStatus</selected>
+					<selected>!Skin.HasSetting(ShowPVRStatus)</selected>
 					<onclick>Skin.ToggleSetting(ShowPVRStatus)</onclick>
 					<visible>Window.IsActive(MyPVRGuide.xml) | [Window.IsActive(MyPVRChannels.xml) + [String.IsEqual(Container.ViewMode,$LOCALIZE[535]) | String.IsEqual(Container.ViewMode,$LOCALIZE[31107]) | String.IsEqual(Container.ViewMode,$LOCALIZE[31108])]]</visible>
 				</control>


### PR DESCRIPTION
I was having this error in kodi.log

ERROR <general>: unmatched parentheses in skin.hassetting(showpvrstatus