### PR TITLE
Fix missing labels

### DIFF
--- a/xml/service-CoreELEC-Settings-mainWindow.xml
+++ b/xml/service-CoreELEC-Settings-mainWindow.xml
@@ -34,7 +34,7 @@
 					<textcolor>$VAR[SkinColorVar]</textcolor>
 					<align>left</align>
 					<aligny>center</aligny>
-					<label>$ADDON[service.libreelec.settings 606]</label>
+					<label>$ADDON[service.coreelec.settings 606]</label>
 				</control>
 				<control type="label">
 					<left>300</left>
@@ -53,7 +53,7 @@
 					<textcolor>$VAR[SkinColorVar]</textcolor>
 					<align>left</align>
 					<aligny>center</aligny>
-					<label>$ADDON[service.libreelec.settings 607]</label>
+					<label>$ADDON[service.coreelec.settings 607]</label>
 				</control>
 				<control type="label">
 					<left>300</left>
@@ -72,7 +72,7 @@
 					<textcolor>$VAR[SkinColorVar]</textcolor>
 					<align>left</align>
 					<aligny>center</aligny>
-					<label>$ADDON[service.libreelec.settings 608]</label>
+					<label>$ADDON[service.coreelec.settings 608]</label>
 				</control>
 				<control type="label">
 					<left>300</left>
@@ -90,7 +90,7 @@
 					<height>300</height>
 					<font>font12</font>
 					<align>justify</align>
-					<label>$ADDON[service.libreelec.settings 609]</label>
+					<label>$ADDON[service.coreelec.settings 609]</label>
 				</control>
 				<control type="textbox">
 					<left>60</left>
@@ -99,7 +99,7 @@
 					<height>400</height>
 					<font>font12</font>
 					<align>justify</align>
-					<label>$ADDON[service.libreelec.settings 610]</label>
+					<label>$ADDON[service.coreelec.settings 610]</label>
 				</control>
 				<control type="textbox">
 					<left>60</left>
@@ -306,7 +306,7 @@
 						<width>380</width>
 						<height>20</height>
 						<font>font12</font>
-						<label>$ADDON[service.libreelec.settings 601] : $INFO[ListItem.Property(Interface)]</label>
+						<label>$ADDON[service.coreelec.settings 601] : $INFO[ListItem.Property(Interface)]</label>
 						<visible>!String.IsEmpty(ListItem.Property(Interface))</visible>
 					</control>
 					<!-- Connection Address -->
@@ -317,7 +317,7 @@
 						<height>20</height>
 						<font>font12</font>
 						<visible>String.IsEqual(ListItem.Property(State), online) | String.IsEqual(ListItem.Property(State), ready)</visible>
-						<label>$ADDON[service.libreelec.settings 602] : $INFO[ListItem.Property(Address)]</label>
+						<label>$ADDON[service.coreelec.settings 602] : $INFO[ListItem.Property(Address)]</label>
 					</control>
 					<!-- Method -->
 					<control type="label">
@@ -326,7 +326,7 @@
 						<width>200</width>
 						<height>20</height>
 						<font>font12</font>
-						<label>$ADDON[service.libreelec.settings 603] : $INFO[ListItem.Property(Method)]</label>
+						<label>$ADDON[service.coreelec.settings 603] : $INFO[ListItem.Property(Method)]</label>
 					</control>
 					<!-- State -->
 					<control type="label">
@@ -335,7 +335,7 @@
 						<width>200</width>
 						<height>20</height>
 						<font>font12</font>
-						<label>$ADDON[service.libreelec.settings 604] : $INFO[ListItem.Property(State)]</label>
+						<label>$ADDON[service.coreelec.settings 604] : $INFO[ListItem.Property(State)]</label>
 					</control>
 					<!-- Signal strength -->
 					<control type="progress">
@@ -443,7 +443,7 @@
 						<width>380</width>
 						<height>20</height>
 						<font>font12</font>
-						<label>$ADDON[service.libreelec.settings 601] : $INFO[ListItem.Property(Interface)]</label>
+						<label>$ADDON[service.coreelec.settings 601] : $INFO[ListItem.Property(Interface)]</label>
 						<visible>!String.IsEmpty(ListItem.Property(Interface))</visible>
 					</control>
 					<!-- Connection Address -->
@@ -454,7 +454,7 @@
 						<height>20</height>
 						<font>font12</font>
 						<visible>String.IsEqual(ListItem.Property(State), online) | String.IsEqual(ListItem.Property(State), ready)</visible>
-						<label>$ADDON[service.libreelec.settings 602] : $INFO[ListItem.Property(Address)]</label>
+						<label>$ADDON[service.coreelec.settings 602] : $INFO[ListItem.Property(Address)]</label>
 					</control>
 					<!-- Method -->
 					<control type="label">
@@ -463,7 +463,7 @@
 						<width>200</width>
 						<height>20</height>
 						<font>font12</font>
-						<label>$ADDON[service.libreelec.settings 603] : $INFO[ListItem.Property(Method)]</label>
+						<label>$ADDON[service.coreelec.settings 603] : $INFO[ListItem.Property(Method)]</label>
 					</control>
 					<!-- State -->
 					<control type="label">
@@ -472,7 +472,7 @@
 						<width>200</width>
 						<height>20</height>
 						<font>font12</font>
-						<label>$ADDON[service.libreelec.settings 604] : $INFO[ListItem.Property(State)]</label>
+						<label>$ADDON[service.coreelec.settings 604] : $INFO[ListItem.Property(State)]</label>
 					</control>
 					<!-- Signal strength -->
 					<control type="progress">
@@ -693,7 +693,7 @@
 						<height>20</height>
 						<font>font13</font>
 						<aligny>center</aligny>
-						<label>$ADDON[service.libreelec.settings 605] : $INFO[ListItem.Property(Address)]</label>
+						<label>$ADDON[service.coreelec.settings 605] : $INFO[ListItem.Property(Address)]</label>
 					</control>
 					<!-- Connected State -->
 					<control type="label">
@@ -703,7 +703,7 @@
 						<height>20</height>
 						<font>font13</font>
 						<aligny>center</aligny>
-						<label>$ADDON[service.libreelec.settings 32333] $INFO[ListItem.Property(ConnectedState)]</label>
+						<label>$ADDON[service.coreelec.settings 32333] $INFO[ListItem.Property(ConnectedState)]</label>
 					</control>
 					<!-- Paired Symbol (bottom right) -->
 					<control type="image">
@@ -871,7 +871,7 @@
 						<height>20</height>
 						<font>font13</font>
 						<aligny>center</aligny>
-						<label>$ADDON[service.libreelec.settings 605] : $INFO[ListItem.Property(Address)]</label>
+						<label>$ADDON[service.coreelec.settings 605] : $INFO[ListItem.Property(Address)]</label>
 					</control>
 					<!-- Connected State -->
 					<control type="label">
@@ -881,7 +881,7 @@
 						<height>20</height>
 						<font>font13</font>
 						<aligny>center</aligny>
-						<label>$ADDON[service.libreelec.settings 32333] $INFO[ListItem.Property(ConnectedState)]</label>
+						<label>$ADDON[service.coreelec.settings 32333] $INFO[ListItem.Property(ConnectedState)]</label>
 					</control>
 					<!-- Paired Symbol (bottom right) -->
 					<control type="image">
@@ -1026,7 +1026,7 @@
 			</control>
 		</control>
 		<include content="TopBar">
-			<param name="breadcrumbs_label" value="$ADDON[service.libreelec.settings 600]" />
+			<param name="breadcrumbs_label" value="$ADDON[service.coreelec.settings 600]" />
 		</include>
 		<include content="BottomBar">
 			<param name="info_visible" value="true" />


### PR DESCRIPTION
labels were pointing to service.libreelec.settings instead of service.coreelec.settings