### PR TITLE
Show [Title] and [Year] labels on wall views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .gitignore
 .idea/*
 xml/script-skinshortcuts-includes.xml
+/.vs/skin.estuary.modv2/v17
+/.vs/skin.estuary.modv2/FileContentIndex
+/.vs

--- a/language/resource.language.en_gb/strings.po
+++ b/language/resource.language.en_gb/strings.po
@@ -2742,3 +2742,8 @@ msgstr ""
 msgctxt "#31655"
 msgid "Show Battery Level"
 msgstr ""
+
+#: /xml/SkinSettings.xml
+msgctxt "#31656"
+msgid "Show [Title] and [Year] labels on Wall views"
+msgstr ""

--- a/xml/SkinSettings.xml
+++ b/xml/SkinSettings.xml
@@ -1214,6 +1214,12 @@
 					<onclick>Skin.ToggleSetting(background_showvisualisation)</onclick>
 					<selected>!Skin.HasSetting(background_showvisualisation)</selected>
 				</control>
+				<control type="radiobutton" id="723">
+					<label>$LOCALIZE[31656]</label>
+					<include>DefaultSettingButton</include>
+					<onclick>Skin.ToggleSetting(wallview_labels)</onclick>
+          <selected>!Skin.HasSetting(wallview_labels)</selected>
+				</control>
 			</control>
 			<control type="grouplist" id="600">
 				<top>168</top>

--- a/xml/View_51_Poster.xml
+++ b/xml/View_51_Poster.xml
@@ -50,7 +50,7 @@
 						<control type="group">
 							<left>-220</left>
 							<top>19</top>
-							<include>InfoWallMovieLayout</include>
+							<include>PostersMovieLayout</include>
 						</control>
 					</itemlayout>
 					<focusedlayout width="490">
@@ -61,7 +61,7 @@
 								<visible>Container.OnScrollPrevious</visible>
 								<visible>Control.IsVisible(20000)</visible>
 								<animation effect="fade" time="200" start="100" end="0">Hidden</animation>
-								<include>InfoWallMovieLayout</include>
+								<include>PostersMovieLayout</include>
 							</control>
 							<control type="group">
 								<left>-40</left>
@@ -69,7 +69,7 @@
 								<visible>Container.OnScrollNext</visible>
 								<visible>Control.IsVisible(20000)</visible>
 								<animation effect="fade" time="200" start="100" end="0">Hidden</animation>
-								<include>InfoWallMovieLayout</include>
+								<include>PostersMovieLayout</include>
 							</control>
 						</control>
 					</focusedlayout>

--- a/xml/View_54_InfoWall.xml
+++ b/xml/View_54_InfoWall.xml
@@ -1536,23 +1536,43 @@
 			</control>
 			<control type="group">
 				<left>135</left>
-				<top>-9</top>
+				<top>-7</top>
 				<include condition="Skin.HasSetting(circle_rating) | Skin.HasSetting(circle_userrating) | Skin.HasSetting(circle_bothrating)">RatingCircle</include>
 			</control>
 			<control type="group">
 				<left>135</left>
-				<top>-9</top>
+				<top>-7</top>
 				<visible>!$PARAM[focused]</visible>
 				<visible>Skin.HasSetting(greyedout_watched) + Integer.IsGreater(ListItem.Playcount,0) + !Window.IsVisible(Home)</visible>
 				<include condition="Skin.HasSetting(circle_rating) | Skin.HasSetting(circle_userrating) | Skin.HasSetting(circle_bothrating)">RatingCircleGreyed</include>
 			</control>
 			<control type="group">
 				<left>135</left>
-				<top>-9</top>
+				<top>-7</top>
 				<visible>!$PARAM[focused]</visible>
 				<visible>Skin.HasSetting(greyedout_watched_home) + Integer.IsGreater(ListItem.Playcount,0) + Window.IsVisible(Home)  + !String.IsEqual(listitem.dbtype,genre)</visible>
 				<include condition="Skin.HasSetting(circle_rating) | Skin.HasSetting(circle_userrating) | Skin.HasSetting(circle_bothrating)">RatingCircleGreyed</include>
 			</control>
+      <control type="label">
+        <visible>!Window.IsVisible(Home) + !Skin.HasSetting(wallview_labels)</visible>
+        <label>$INFO[ListItem.Label]</label>
+        <font>font09</font>
+        <align>center</align>
+        <left>50</left>
+        <right>30</right>
+        <top>373</top>
+        <scroll>$PARAM[focused]</scroll>
+      </control>
+      <control type="label">
+        <visible>!Window.IsVisible(Home) + !ListItem.IsCollection + !Skin.HasSetting(wallview_labels)</visible>
+        <label>$INFO[ListItem.Year]</label>
+        <align>center</align>
+        <aligny>top</aligny>
+        <font>font09</font>
+        <left>50</left>
+        <right>30</right>
+        <top>397</top>
+      </control>
 			<include>InfoWallProgressLayout</include>
 			<control type="group">
 				<top>195</top>
@@ -1818,6 +1838,355 @@
 			</control>
 		</definition>
 	</include>
+  <include name="PostersMovieLayout">
+    <param name="focused">false</param>
+    <definition>
+      <control type="group">
+        <visible>[String.IsEmpty(ListItem.Art(poster)) + String.IsEmpty(ListItem.Art(tvshow.poster)) + String.IsEmpty(ListItem.Art(season.poster)) + String.IsEmpty(ListItem.Art(animatedposter))]</visible>
+        <control type="image">
+          <left>13</left>
+          <top>-12</top>
+          <width>294</width>
+          <height>404</height>
+          <texture colordiffuse="$VAR[BorderColorVar]">dialogs/border-movielayout.png</texture>
+          <aspectratio>stretch</aspectratio>
+          <bordertexture border="21">overlays/shadow.png</bordertexture>
+          <bordersize>20</bordersize>
+          <visible>Skin.HasSetting(show_borders) + !String.IsEqual(listitem.dbtype,genre)</visible>
+        </control>
+        <control type="image">
+          <left>15</left>
+          <top>-10</top>
+          <width>290</width>
+          <height>400</height>
+          <texture>dialogs/dialog-bg-nobo.png</texture>
+          <bordersize>20</bordersize>
+          <visible>Skin.HasSetting(show_borders) + !String.IsEqual(listitem.dbtype,genre)</visible>
+        </control>
+        <control type="image">
+          <left>15</left>
+          <top>-10</top>
+          <width>290</width>
+          <height>400</height>
+          <texture>dialogs/dialog-bg-nobo.png</texture>
+          <bordertexture border="21">overlays/shadow.png</bordertexture>
+          <bordersize>20</bordersize>
+          <visible>Skin.HasSetting(show_borders) + String.IsEqual(listitem.dbtype,genre)</visible>
+        </control>
+        <control type="image">
+          <left>15</left>
+          <top>-10</top>
+          <width>290</width>
+          <height>400</height>
+          <texture>dialogs/dialog-bg-nobo.png</texture>
+          <bordertexture border="21">overlays/shadow.png</bordertexture>
+          <bordersize>20</bordersize>
+          <visible>!Skin.HasSetting(show_borders)</visible>
+        </control>
+        <control type="image">
+          <left>9</left>
+          <top>-16</top>
+          <width>302</width>
+          <height>412</height>
+          <texture colordiffuse="$VAR[SkinColorVar]">colors/grey.png</texture>
+          <bordertexture border="21">overlays/shadow.png</bordertexture>
+          <bordersize>20</bordersize>
+          <visible>$PARAM[focused]</visible>
+        </control>
+        <control type="image">
+          <left>9</left>
+          <top>-16</top>
+          <width>302</width>
+          <height>412</height>
+          <texture colordiffuse="$VAR[GradientColorVar]">colors/gradient.png</texture>
+          <bordersize>20</bordersize>
+          <visible>$PARAM[focused]</visible>
+          <visible>Skin.HasSetting(EnableGradientColor)</visible>
+        </control>
+        <control type="textbox">
+          <left>40</left>
+          <top>244</top>
+          <width>242</width>
+          <height>120</height>
+          <font>font27</font>
+          <align>center</align>
+          <aligny>center</aligny>
+          <label>$INFO[ListItem.Label]</label>
+          <autoscroll time="2000" delay="3000" repeat="5000">$PARAM[focused]</autoscroll>
+          <visible>!ListItem.IsParentFolder</visible>
+          <visible>![!Skin.HasSetting(HideWidgetLabels) + Window.IsVisible(Home)  + String.IsEqual(listitem.dbtype,genre)]</visible>
+        </control>
+        <control type="image">
+          <left>24</left>
+          <top>-1</top>
+          <width>272</width>
+          <height>270</height>
+          <texture fallback="DefaultMovies.png" background="true">$INFO[ListItem.Icon]</texture>
+          <aspectratio>scale</aspectratio>
+          <bordersize>20</bordersize>
+          <visible>!String.IsEqual(listitem.dbtype,genre)</visible>
+        </control>
+        <control type="image">
+          <left>54</left>
+          <top>40</top>
+          <width>212</width>
+          <height>212</height>
+          <texture fallback="DefaultGenre.png">$VAR[WidgetGenreIconVar]</texture>
+          <aspectratio align="center" aligny="center">keep</aspectratio>
+          <visible>String.IsEqual(listitem.dbtype,genre)</visible>
+          <animation effect="slide" end="0,44" time="0" condition="[!Skin.HasSetting(HideWidgetLabels) + Window.IsVisible(Home)]">Conditional</animation>
+        </control>
+      </control>
+      <control type="group">
+        <visible>![String.IsEmpty(ListItem.Art(poster)) + String.IsEmpty(ListItem.Art(tvshow.poster)) + String.IsEmpty(ListItem.Art(season.poster)) + String.IsEmpty(ListItem.Art(animatedposter))]</visible>
+        <control type="image">
+          <left>9</left>
+          <top>-16</top>
+          <width>302</width>
+          <height>412</height>
+          <texture colordiffuse="$VAR[SkinColorVar]">colors/grey.png</texture>
+          <bordertexture border="21">overlays/shadow.png</bordertexture>
+          <bordersize>20</bordersize>
+          <visible>$PARAM[focused]</visible>
+        </control>
+        <control type="image">
+          <left>9</left>
+          <top>-16</top>
+          <width>302</width>
+          <height>412</height>
+          <texture colordiffuse="$VAR[GradientColorVar]">colors/gradient.png</texture>
+          <bordersize>20</bordersize>
+          <visible>$PARAM[focused]</visible>
+          <visible>Skin.HasSetting(EnableGradientColor)</visible>
+        </control>
+        <control type="image">
+          <left>15</left>
+          <top>-10</top>
+          <width>290</width>
+          <height>400</height>
+          <texture background="true">$VAR[IconWallPosterVar]</texture>
+          <aspectratio>stretch</aspectratio>
+          <bordersize>20</bordersize>
+          <visible>$PARAM[focused]</visible>
+        </control>
+        <control type="image">
+          <left>13</left>
+          <top>-12</top>
+          <width>294</width>
+          <height>404</height>
+          <texture colordiffuse="$VAR[BorderColorVar]">dialogs/border-movielayout.png</texture>
+          <aspectratio>stretch</aspectratio>
+          <bordertexture border="21">overlays/shadow.png</bordertexture>
+          <bordersize>20</bordersize>
+          <visible>!$PARAM[focused]</visible>
+          <visible>Skin.HasSetting(show_borders)</visible>
+        </control>
+        <control type="image">
+          <left>15</left>
+          <top>-10</top>
+          <width>290</width>
+          <height>400</height>
+          <texture background="true">$VAR[IconWallPosterVar]</texture>
+          <aspectratio>stretch</aspectratio>
+          <bordersize>20</bordersize>
+          <visible>!$PARAM[focused]</visible>
+          <visible>Skin.HasSetting(show_borders)</visible>
+        </control>
+        <control type="image">
+          <left>15</left>
+          <top>-10</top>
+          <width>290</width>
+          <height>400</height>
+          <texture background="true">$VAR[IconWallPosterVar]</texture>
+          <aspectratio>stretch</aspectratio>
+          <bordertexture border="21">overlays/shadow.png</bordertexture>
+          <bordersize>20</bordersize>
+          <visible>!$PARAM[focused]</visible>
+          <visible>!Skin.HasSetting(show_borders)</visible>
+        </control>
+        <control type="image">
+          <left>35</left>
+          <top>290</top>
+          <width>80</width>
+          <height>80</height>
+          <texture>overlays/overlay-bg.png</texture>
+          <visible>ListItem.IsResumable | Listitem.IsCollection | ListItem.IsPlaying | Integer.IsGreater(ListItem.Playcount,0)</visible>
+          <visible>!String.IsEqual(listitem.dbtype,genre)</visible>
+        </control>
+      </control>
+      <control type="group">
+        <visible>String.IsEqual(ListItem.DBtype,tvshow)</visible>
+        <top>320</top>
+        <control type="image">
+          <left>35</left>
+          <top>0</top>
+          <width>250</width>
+          <height>50</height>
+          <texture colordiffuse="CCFFFFFF">overlays/overlayfade.png</texture>
+          <visible>!String.IsEmpty(ListItem.Art(poster)) + !String.IsEmpty(ListItem.Property(WatchedEpisodes)) + !String.IsEmpty(ListItem.Property(TotalEpisodes))</visible>
+        </control>
+        <control type="label">
+          <left>0</left>
+          <top>20</top>
+          <width>244</width>
+          <label>$INFO[ListItem.Property(WatchedEpisodes)]$INFO[ListItem.Property(TotalEpisodes), / ,]</label>
+          <font>font20_title</font>
+          <shadowcolor>text_shadow</shadowcolor>
+          <align>right</align>
+        </control>
+        <control type="image">
+          <left>254</left>
+          <top>23</top>
+          <width>24</width>
+          <height>24</height>
+          <texture>lists/played-total.png</texture>
+          <visible>!String.IsEmpty(ListItem.Property(WatchedEpisodes)) + !String.IsEmpty(ListItem.Property(TotalEpisodes))</visible>
+        </control>
+      </control>
+      <control type="image">
+        <left>35</left>
+        <top>338</top>
+        <width>32</width>
+        <height>32</height>
+        <texture>$VAR[WallWatchedIconVar]</texture>
+        <visible>!String.IsEqual(listitem.dbtype,genre)</visible>
+      </control>
+      <control type="image">
+        <left>35</left>
+        <top>10</top>
+        <width>250</width>
+        <height>360</height>
+        <texture background="true" colordiffuse="BFFFFFFF">colors/black.png</texture>
+        <aspectratio>stretch</aspectratio>
+        <visible>!$PARAM[focused]</visible>
+        <visible>Skin.HasSetting(greyedout_watched) + Integer.IsGreater(ListItem.Playcount,0) + !Window.IsVisible(Home) + !Skin.HasSetting(show_borders) + !String.IsEqual(listitem.dbtype,genre)</visible>
+      </control>
+      <control type="image">
+        <left>33</left>
+        <top>8</top>
+        <width>254</width>
+        <height>364</height>
+        <texture background="true" colordiffuse="BFFFFFFF">colors/black.png</texture>
+        <aspectratio>stretch</aspectratio>
+        <visible>!$PARAM[focused]</visible>
+        <visible>Skin.HasSetting(greyedout_watched) + Integer.IsGreater(ListItem.Playcount,0) + !Window.IsVisible(Home) + Skin.HasSetting(show_borders) + !String.IsEqual(listitem.dbtype,genre)</visible>
+      </control>
+      <control type="image">
+        <left>35</left>
+        <top>10</top>
+        <width>250</width>
+        <height>360</height>
+        <texture background="true" colordiffuse="BFFFFFFF">colors/black.png</texture>
+        <aspectratio>stretch</aspectratio>
+        <visible>!$PARAM[focused]</visible>
+        <visible>Skin.HasSetting(greyedout_watched_home) + Integer.IsGreater(ListItem.Playcount,0) + Window.IsVisible(Home) + !Skin.HasSetting(show_borders) + !String.IsEqual(listitem.dbtype,genre)</visible>
+      </control>
+      <control type="image">
+        <left>33</left>
+        <top>8</top>
+        <width>254</width>
+        <height>364</height>
+        <texture background="true" colordiffuse="BFFFFFFF">colors/black.png</texture>
+        <aspectratio>stretch</aspectratio>
+        <visible>!$PARAM[focused]</visible>
+        <visible>Skin.HasSetting(greyedout_watched_home) + Integer.IsGreater(ListItem.Playcount,0) + Window.IsVisible(Home) + Skin.HasSetting(show_borders)  + !String.IsEqual(listitem.dbtype,genre)</visible>
+      </control>
+      <control type="group">
+        <left>135</left>
+        <top>-7</top>
+        <include condition="Skin.HasSetting(circle_rating) | Skin.HasSetting(circle_userrating) | Skin.HasSetting(circle_bothrating)">RatingCircle</include>
+      </control>
+      <control type="group">
+        <left>135</left>
+        <top>-7</top>
+        <visible>!$PARAM[focused]</visible>
+        <visible>Skin.HasSetting(greyedout_watched) + Integer.IsGreater(ListItem.Playcount,0) + !Window.IsVisible(Home)</visible>
+        <include condition="Skin.HasSetting(circle_rating) | Skin.HasSetting(circle_userrating) | Skin.HasSetting(circle_bothrating)">RatingCircleGreyed</include>
+      </control>
+      <control type="group">
+        <left>135</left>
+        <top>-7</top>
+        <visible>!$PARAM[focused]</visible>
+        <visible>Skin.HasSetting(greyedout_watched_home) + Integer.IsGreater(ListItem.Playcount,0) + Window.IsVisible(Home)  + !String.IsEqual(listitem.dbtype,genre)</visible>
+        <include condition="Skin.HasSetting(circle_rating) | Skin.HasSetting(circle_userrating) | Skin.HasSetting(circle_bothrating)">RatingCircleGreyed</include>
+      </control>
+      <control type="image">
+        <left>35</left>
+        <top>380</top>
+        <width>250</width>
+        <height>4</height>
+        <texture>dialogs/back.png</texture>
+        <visible>!Integer.IsEqual(ListItem.PercentPlayed,0)</visible>
+      </control>
+      <control type="progress">
+        <left>35</left>
+        <top>352</top>
+        <width>250</width>
+        <height>1</height>
+        <texturebg></texturebg>
+        <midtexture colordiffuse="$VAR[SkinColorVar]" border="3">progress/texturebg_alt_white.png</midtexture>
+        <info>ListItem.PercentPlayed</info>
+        <visible>!Integer.IsEqual(ListItem.PercentPlayed,0)</visible>
+      </control>
+      <control type="image">
+        <left>35</left>
+        <top>352</top>
+        <width>250</width>
+        <height>4</height>
+        <texture>dialogs/back.png</texture>
+        <visible>!Integer.IsEqual(ListItem.Progress,0)</visible>
+      </control>
+      <control type="progress">
+        <left>35</left>
+        <top>352</top>
+        <width>250</width>
+        <height>1</height>
+        <texturebg></texturebg>
+        <midtexture colordiffuse="$VAR[SkinColorVar]" border="3">progress/texturebg_alt_white.png</midtexture>
+        <info>ListItem.Progress</info>
+        <visible>!Integer.IsEqual(ListItem.Progress,0)</visible>
+      </control>
+      <control type="group">
+        <top>195</top>
+        <visible>[Skin.HasSetting(enable_LibraryDiscArt) + !Window.IsVisible(Home)] | [Skin.HasSetting(enable_HomeDiscArt) + Window.IsVisible(Home)]</visible>
+        <visible>$PARAM[focused]</visible>
+        <visible>!String.IsEmpty(ListItem.Art(discart)) + !ListItem.IsCollection</visible>
+        <visible>!Window.IsVisible(script-script.extendedinfo-DialogVideoInfo.xml) + !Window.IsVisible(script-script.extendedinfo-DialogInfo.xml)</visible>
+        <animation effect="slide" start="0,50" end="0,0" time="300" tween="cubic" easing="out" reversible="false">Focus</animation>
+        <animation effect="fade" start="100" end="0" time="0">UnFocus</animation>
+        <animation effect="slide" end="56,0" time="0" condition="Window.IsVisible(Home)">Conditional</animation>
+        <animation effect="slide" end="11,0" time="0" condition="Control.IsVisible(54) | [String.IsEqual(Container.ViewMode,$LOCALIZE[31101]) + [Window.IsVisible(DialogSelect.xml) | Window.IsVisible(DialogContextMenu.xml) | Window.IsVisible(DialogBusy.xml) | Window.IsVisible(DialogKeyboard.xml) | Window.IsVisible(DialogConfirm.xml) | Window.IsVisible(DialogVideoInfo.xml)]]">Conditional</animation>
+        <animation effect="slide" end="8,0" time="0" condition="Window.IsVisible(script-globalsearch-main.xml) | Window.IsVisible(script-globalsearch.xml)">Conditional</animation>
+        <control type="image">
+          <right>-6</right>
+          <top>0</top>
+          <width>172</width>
+          <height>172</height>
+          <texture background="true" colordiffuse="$VAR[SkinColorVar]">overlays/circle-172.png</texture>
+          <aspectratio>keep</aspectratio>
+          <visible>[!Skin.HasSetting(enable_LibraryDiscArtOverlay) + !Window.IsVisible(Home)] | [!Skin.HasSetting(enable_HomeDiscArtOverlay) + Window.IsVisible(Home)]</visible>
+        </control>
+        <control type="image">
+          <right>-6</right>
+          <top>0</top>
+          <width>172</width>
+          <height>172</height>
+          <texture background="true" colordiffuse="$VAR[GradientColorVar]">overlays/circle-172-gradient.png</texture>
+          <aspectratio>keep</aspectratio>
+          <visible>[!Skin.HasSetting(enable_LibraryDiscArtOverlay) + !Window.IsVisible(Home)] | [!Skin.HasSetting(enable_HomeDiscArtOverlay) + Window.IsVisible(Home)]</visible>
+          <visible>Skin.HasSetting(EnableGradientColor)</visible>
+        </control>
+        <control type="image">
+          <right>-5</right>
+          <top>1</top>
+          <width>170</width>
+          <height>170</height>
+          <texture background="true">$INFO[ListItem.Art(discart)]</texture>
+          <aspectratio>keep</aspectratio>
+        </control>
+      </control>
+    </definition>
+  </include>
 	<include name="WallThumbsLayout">
 		<param name="focused">false</param>
 		<definition>


### PR DESCRIPTION
Hi b-jesch,

I just added an option to show the title and year labels on wall views, similar to Embuary. Although wall and infowall views are my favourite ones, sometimes media posters can be a bit messy to read, so I find it easier to have the title and year there.

Please, let me know your thoughts.

Thank you so much for keeping this skin alive. Estuary.mod2 is the best skin so far. It is simple and beautiful.

Cheers.