### PR TITLE
Fix infowall side panel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .gitignore
 .idea/*
 xml/script-skinshortcuts-includes.xml
+/.vs

--- a/xml/MyVideoNav.xml
+++ b/xml/MyVideoNav.xml
@@ -38,7 +38,6 @@
 				<depth>DepthContentPanel</depth>
 				<include>OpenClose_Left</include>
 				<visible>Control.IsVisible(50) | Control.IsVisible(54) | Control.IsVisible(505) | [Control.IsVisible(501) + String.IsEqual(Skin.AspectRatio,21:9)]</visible>
-				<visible>!Window.IsActive(DialogBusy.xml)</visible>
 				<include>Visible_Left</include>
 				<top>40</top>
 				<include content="ContentPanel">


### PR DESCRIPTION
Hi @b-jesch,

It's just a minor cosmetic fix for the infowall view side panel.
The side panel disappears when the busy spin wheel shows up.

 
![Screenshot 2023-08-27 104012](https://github.com/b-jesch/skin.estuary.modv2/assets/9671193/050655b0-9409-45a0-ab43-5e28ac549301)

![Screenshot 2023-08-27 103907](https://github.com/b-jesch/skin.estuary.modv2/assets/9671193/26f5804e-7490-4834-8b82-8a8495dbc4ea)
