### PR TITLE
OSD hide button for sound if video has not multiple audio tracks

### DIFF
--- a/xml/VideoOSD.xml
+++ b/xml/VideoOSD.xml
@@ -278,6 +278,7 @@
 					</include>
 					<onclick condition="!Skin.HasSetting(SimplyfiedOSDVideo)">AudioNextLanguage</onclick>
 					<onclick condition="Skin.HasSetting(SimplyfiedOSDVideo)">ActivateWindow(osdaudiosettings)</onclick>
+					<visible>Skin.HasSetting(SimplyfiedOSDVideo) | Integer.IsGreater(VideoPlayer.AudioStreamCount,1)</visible>
 				</control>
 				<control type="radiobutton" id="706">
 					<include content="OSDButton">


### PR DESCRIPTION
in non-simplified navigation, purpose of the OSD button is to change to the next audio track in a video with multiple audio tracks, this hides this button if video has not multiple audio tracks

