### PR TITLE
Update SkinSettings.xml

### DIFF
--- a/xml/SkinSettings.xml
+++ b/xml/SkinSettings.xml
@@ -756,6 +756,7 @@
 				</control>
 				<control type="radiobutton" id="510">
 					<label>$LOCALIZE[31670]</label>
+					<visible>System.HasAddon(service.coreelec.settings)</visible>
 					<include>DefaultSettingButton</include>
 					<onclick>Skin.ToggleSetting(ShowVideoResolution)</onclick>
 					<selected>Skin.HasSetting(ShowVideoResolution)</selected>


### PR DESCRIPTION
Show video resolution working just in the CoreElec system. In this way when the service.coreelec.settings addon not present, then the  button not visible.