### PR TITLE
Improve the  Atmos and the dts-x flag in video OSD.

### DIFF
--- a/xml/Variables.xml
+++ b/xml/Variables.xml
@@ -1716,8 +1716,9 @@
 		<value>$INFO[ListItem.AudioCodec,flags/audiocodec/,.png]</value>
 	</variable>
 	<variable name="VideoPlayerAudioCodecFlagVar">
-		<value condition="String.Contains(Player.Filenameandpath,ATMOS)">flags/audiocodec/atmos.png</value>
-		<value condition="String.Contains(Player.Filenameandpath,DTS-X) | String.Contains(Player.Filenameandpath,DTSX)">flags/audiocodec/dts-x.png</value>
+		<value condition="String.Contains(VideoPlayer.AudioCodec,truehd) + String.Contains(Player.Filenameandpath,ATMOS)">flags/audiocodec/atmos.png</value>
+		<value condition="String.Contains(VideoPlayer.AudioCodec,dtshd_ma) + String.Contains(Player.Filenameandpath,DTS-X) | String.Contains(Player.Filenameandpath,DTSX)">flags/audiocodec/dts-x.png</value>
+		<value condition="String.Contains(VideoPlayer.AudioCodec,dtsma) + String.Contains(Player.Filenameandpath,DTS-X) | String.Contains(Player.Filenameandpath,DTSX)">flags/audiocodec/dts-x.png</value>
 		<value>$INFO[VideoPlayer.AudioCodec,flags/audiocodec/,.png]</value>
 	</variable>
 	<variable name="Container6_AudioCodecFlagVar">


### PR DESCRIPTION
The Atmos and the dts-x flag always visible in video OSD. it doesn't matter what it is the actual audio codec during movie play, when filename tag exist. With this mod, just visible, when the right codec + filename together true. All other codec will be shown the right flag after we switch the audio.